### PR TITLE
Speed up, make node 4.x-compatible

### DIFF
--- a/arraybuffer-to-buffer.js
+++ b/arraybuffer-to-buffer.js
@@ -1,6 +1,13 @@
 (function(root) {
+  var isArrayBufferSupported = new Buffer(new Uint8Array([1]).buffer)[0] === 1;
 
-  function ArrayBufferToBuffer(ab) {
+  var ArrayBufferToBuffer = isArrayBufferSupported ? ArrayBufferToBufferAsArgument : ArrayBufferToBufferPerElement;
+
+  function ArrayBufferToBufferAsArgument (ab) {
+    return new Buffer(ab);
+  }
+
+  function ArrayBufferToBufferPerElement (ab) {
     var buffer = new Buffer(ab.byteLength);
     var view = new Uint8Array(ab);
     for (var i = 0; i < buffer.length; ++i) {

--- a/test/arraybuffer-to-buffer.js
+++ b/test/arraybuffer-to-buffer.js
@@ -1,9 +1,9 @@
 var test = require('tape');
 var ArrayBufferToBuffer = require('../arraybuffer-to-buffer');
 
-function bufferEqual(a, b) {
+function arrayBufferEqualBuffer(a, b) {
   for (var i = 0; i < a.length; i++) {
-      if (a[i] !== b[i]) return false;
+      if (a.getUint8(i) !== b[i]) return false;
   }
   return true;
 }
@@ -15,12 +15,12 @@ test('ArrayBufferToBuffer', function (t) {
 
   var ab = new ArrayBuffer(12);
   var v = new DataView(ab);
-  [].slice.call(str).forEach(function(s, i) {
-    v[i] = s.charCodeAt(0);
+  str.split('').forEach(function(s, i) {
+    v.setUint8(i, s.charCodeAt(0));
   });
 
   var b = ArrayBufferToBuffer(ab);
 
-  t.strictEqual(bufferEqual(b, ab), true);
+  t.strictEqual(arrayBufferEqualBuffer(ab, b), true);
   t.equal(b.toString('utf8', 0, 3), str);
 });


### PR DESCRIPTION
At first, since node 4.x+ we cannot access _ArrayBuffer_ instance like `arrayBuffer[idx]`, we gotta explicitly point the type of data we wish, `arrayBuffer.getUint8(idx)`. The tests failed because of that. It is valid for previous node versions.
At second, node 4.x+ can take an _ArrayBuffer_ as an argument for _Buffer()_ constructor, which results in speeding up all thing ~4-5 times, just like cloning _Buffer_.

The code may look somewhat unwieldy though, then I encourage you to apply changes in preferred style :)
