### PR TITLE
Updated buffer instantiation to not use deprecated constructor

### DIFF
--- a/arraybuffer-to-buffer.js
+++ b/arraybuffer-to-buffer.js
@@ -1,14 +1,14 @@
 (function(root) {
-  var isArrayBufferSupported = (new Buffer(new Uint8Array([1]).buffer)[0] === 1);
+  var isArrayBufferSupported = (Buffer.from(new Uint8Array([1]).buffer)[0] === 1);
 
   var arrayBufferToBuffer = isArrayBufferSupported ? arrayBufferToBufferAsArgument : arrayBufferToBufferCycle;
 
   function arrayBufferToBufferAsArgument(ab) {
-    return new Buffer(ab);
+    return Buffer.from(ab);
   }
 
   function arrayBufferToBufferCycle(ab) {
-    var buffer = new Buffer(ab.byteLength);
+    var buffer = Buffer.alloc(ab.byteLength);
     var view = new Uint8Array(ab);
     for (var i = 0; i < buffer.length; ++i) {
         buffer[i] = view[i];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arraybuffer-to-buffer",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Convert ArrayBuffer to Buffer",
   "main": "arraybuffer-to-buffer.js",
   "directories": {


### PR DESCRIPTION
Thanks for the lib! Saved me! I did notice when I ran it that the console showed some depreciation warning. I just updated the script to use the "new" non-deprecated methods.

https://nodejs.org/api/buffer.html#buffer_new_buffer_buffer
https://nodejs.org/api/buffer.html#buffer_new_buffer_size